### PR TITLE
Css Loader bug fix

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -29,7 +29,7 @@ module.exports = {
       {
         test: /\.css$/,
         include: [
-          path.resolve(__dirname, 'not_exist_path'), // fixes issue when try to import css file
+          'src'
         ],
         use: [
           MiniCssExtractPlugin.loader,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,7 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const path = require('path');
 
 const devMode = process.env.NODE_ENV !== 'production';
 const htmlWebpackPlugin = new HtmlWebPackPlugin({
@@ -27,6 +28,9 @@ module.exports = {
       },
       {
         test: /\.css$/,
+        include: [
+          path.resolve(__dirname, 'not_exist_path'), // fixes issue when try to import css file
+        ],
         use: [
           MiniCssExtractPlugin.loader,
           "css-loader"


### PR DESCRIPTION
Compile fails when css file is imported and used in js file using className={somClassName}.