### PR TITLE
fix(prod): css not included in production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "boilerplate",
-  "sideEffects": false,
   "version": "1.0.0",
   "description": "React Boiler Plate",
   "main": "index.js",


### PR DESCRIPTION
Setting side effects to `false` will prevent CSS from being included in the production build. Sadly, whoever wrote it never tested this for production.